### PR TITLE
ahora el tiempo de juego se pausa 

### DIFF
--- a/OpenGL-basico/utils/clock.cpp
+++ b/OpenGL-basico/utils/clock.cpp
@@ -32,8 +32,7 @@ void clock::reset()
 
 Uint32 clock::get_total_time()
 {
-    const Uint32 current_time = instance_->played_time_;
-    return current_time;
+    return instance_->played_time_;
 }
 
 bool clock::get_is_paused() const

--- a/OpenGL-basico/utils/clock.cpp
+++ b/OpenGL-basico/utils/clock.cpp
@@ -9,7 +9,7 @@ void clock::init()
 
 void clock::toggle_pause()
 {
-    instance_->is_pause_ = !(instance_->is_pause_);
+    instance_->is_pause_ = !instance_->is_pause_;
 }
 
 
@@ -21,6 +21,7 @@ double clock::get_ticks()
 
     if (instance_->is_pause_)
         delta_time = 0;
+    instance_->played_time_ = delta_time + instance_->played_time_;
     return delta_time;
 }
 
@@ -31,7 +32,7 @@ void clock::reset()
 
 Uint32 clock::get_total_time()
 {
-    const Uint32 current_time = SDL_GetTicks();
+    const Uint32 current_time = instance_->played_time_;
     return current_time;
 }
 

--- a/OpenGL-basico/utils/clock.h
+++ b/OpenGL-basico/utils/clock.h
@@ -7,8 +7,9 @@ class clock
     double start_time_;
     bool is_pause_ = false;
     static clock* instance_;
+    Uint32 played_time_;
 
-    explicit clock(): start_time_(SDL_GetTicks())
+    explicit clock(): start_time_(SDL_GetTicks()), played_time_(0)
     {
     }
 


### PR DESCRIPTION
le agregue a get_ticks() una linea para reutilizarla y agregue una variable a clock, como get_ticks() se llama siempre en el main siempre se actualiza el tiempo jugado.

Intente hacer una funcion exactamente igual aparte pero los segundos se volvian inconsistentes, creo que es porque al tener dos funciones que calculan los cambios de tiempo se ralentizaba a veces