### PR TITLE
colisiones arregladas

### DIFF
--- a/OpenGL-basico/entities/entity.cpp
+++ b/OpenGL-basico/entities/entity.cpp
@@ -1,4 +1,6 @@
 #include "entity.h"
+#include "../scene/scene.h"
+
 
 std::vector<vertex> entity::get_vertices() const
 {
@@ -44,9 +46,9 @@ bool entity::check_collision(const game_object* other_object) const
 {
     const auto a = get_bounding_box();
     const aabb other = other_object->get_bounding_box();
-    return a.min.get_x() <= other.max.get_x() && a.max.get_x() >= other.min.get_x() &&
-        (a.min.get_y() <= other.max.get_y() && a.max.get_y() >= other.min.get_y()) &&
-        (a.min.get_z() <= other.max.get_z() && a.max.get_z() >= other.min.get_z());
+    return a.min.get_x() - 0.3 <= other.max.get_x() && a.max.get_x() + 0.3 >= other.min.get_x() &&
+        (a.min.get_y() - 0.3 <= other.max.get_y() && a.max.get_y() + 0.3 >= other.min.get_y()) &&
+        (a.min.get_z() - 0.3 <= other.max.get_z() && a.max.get_z() + 0.3 >= other.min.get_z());
 }
 
 aabb entity::get_bounding_box() const

--- a/OpenGL-basico/entities/entity.h
+++ b/OpenGL-basico/entities/entity.h
@@ -6,6 +6,7 @@
 #include "../graphics/vertex.h"
 #include "../textures/texture.h"
 
+
 class entity : public game_object
 {
     std::vector<vertex> vertices_;

--- a/OpenGL-basico/scene/camera.cpp
+++ b/OpenGL-basico/scene/camera.cpp
@@ -71,7 +71,7 @@ void camera::move(const vector3& displacement)
 
 void camera::rotate(const float x_offset, const float y_offset)
 {
-    constexpr float sensitivity = 0.01f; // Adjust this value to make the camera rotation more or less sensitive
+    constexpr float sensitivity = 0.005f; // Adjust this value to make the camera rotation more or less sensitive
 
     direction_.set_x(direction_.get_x() - x_offset * sensitivity);
 

--- a/OpenGL-basico/scene/scene.cpp
+++ b/OpenGL-basico/scene/scene.cpp
@@ -60,6 +60,8 @@ void scene::update_camera() const
     switch (camera_mode_)
     {
     case first:
+        camera_->move(player_->get_speed());
+        break;
     case perspective:
         camera_->move(player_->get_speed());
         break;
@@ -245,10 +247,13 @@ void scene::update_scene(const float elapsed_time)
 {
     player_->move();
 
-    for (auto& block : blocks_)
+    for (const auto& block : blocks_)
+    {
         if (player_->check_collision(block.get()))
+        {
             player_->handle_collision(block.get());
-
+        }
+    }
     for (auto& enemy : enemies_)
     {
         if (player_->check_collision(enemy.get()))

--- a/main.cpp
+++ b/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[])
     constexpr float color = 0;
     glClearColor(color, color, color, 1);
 
-    gluPerspective(45, 640 / 480.f, 0.1, 100);
+    gluPerspective(45, 640 / 480.f, 0.001, 100);
     glMatrixMode(GL_MODELVIEW);
 
     bool fin = false;
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
         //CONSTANTE CON LA QUE MULTIPLICAR LAS ANIMACIONES Y MOVIMIENTOS
         {
         case slow:
-            game_velocity = 0.3f;
+            game_velocity = 0.3;
             break;
         case normal:
             game_velocity = 1;
@@ -145,19 +145,19 @@ void handle_events(settings_screen* settings_screen, scene& current_scene, vecto
             {
             case SDLK_a:
                 std::cout << "LEFT\n";
-                displacement.set_x(0.1f * delta_time);
+                displacement.set_x(0.01f * delta_time);
                 break;
             case SDLK_d:
                 std::cout << "RIGHT\n";
-                displacement.set_x(-0.1f * delta_time);
+                displacement.set_x(-0.01f * delta_time);
                 break;
             case SDLK_w:
                 std::cout << "UP\n";
-                displacement.set_z(0.1f * delta_time);
+                displacement.set_z(0.01f * delta_time);
                 break;
             case SDLK_s:
                 std::cout << "DOWN\n";
-                displacement.set_z(-0.1f * delta_time);
+                displacement.set_z(-0.01f * delta_time);
                 break;
             case SDLK_v:
                 current_scene.toggle_camera();


### PR DESCRIPTION
se puede acercar mas el personaje en las camaras en tercera persona pero luego al cambiar a primera apareces adentro de los bloques, si que pudiera cambiar eso y concidieran la ubicacion de la camara de primera persona con el centro del personaje se puede solucionar.